### PR TITLE
Uplifted eiffel-remrem-parent version from 0.0.5 to 0.0.6 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.12
+- Updated eiffel-remrem-parent version from 0.0.5 to 0.0.6
+  Upgraded Jackson.databind.version from 2.9.4 to 2.9.5 in parent 0.0.6 version
+
 ## 0.0.11
 - Updated eiffel-remrem-parent version
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,10 @@
     <parent>
         <groupId>com.github.Ericsson</groupId>
         <artifactId>eiffel-remrem-parent</artifactId>
-        <version>0.0.5</version>
+        <version>0.0.6</version>
     </parent>
     <artifactId>eiffel-remrem-protocol-interface</artifactId>
-    <version>0.0.11</version>
+    <version>0.0.12</version>
     <repositories>
         <repository>
             <id>jitpack.io</id>


### PR DESCRIPTION
change in jackson.databind.version from 2.9.4 to 2.9.5 in 0.0.6 eiffel-remrem-parent .

